### PR TITLE
Fix test running

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ include_HEADERS = oocairo.h
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = oocairo.pc
 
-TESTS_ENVIRONMENT = echo 'lunit.main({...})' | LUA_PATH='@srcdir@/?.lua' LUA_CPATH='.libs/lib?.so' lua -e 'srcdir="@srcdir@"' -llunit -
+LOG_COMPILER = "@abs_srcdir@/run-test.sh" "${abs_srcdir}"
 TESTS  = test/context.lua
 TESTS += test/font_face.lua
 TESTS += test/font_opt.lua
@@ -32,7 +32,7 @@ TESTS += test/surface.lua
 TESTS += test/svg_surface.lua
 TESTS += test/region.lua
 EXTRA_DIST += examples/images/pattern.png
-EXTRA_DIST += $(TESTS) lunit.lua test-setup.lua lunit-console.lua test-loading.lua
+EXTRA_DIST += $(TESTS) lunit.lua test-setup.lua lunit-console.lua test-loading.lua run-test.sh
 
 # Documentation
 EXTRA_DIST += doc/lua-oocairo.pod doc/lua-oocairo-context.pod doc/lua-oocairo-fontface.pod doc/lua-oocairo-fontopt.pod

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Running tests
 ---------------
 
 The module comes with a test suite in the 'test' directory, which at least
-on Linux systems can be run with 'make test'.  If there are any problems
+on Linux systems can be run with 'make check'.  If there are any problems
 with the test programs being able to load your compiled 'oocairo' module,
 try adjusting the first few lines of 'test-setup.lua'.
 

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+SRCDIR=$1
+shift
+echo 'lunit.main({...})' | LUA_PATH="${SRCDIR}/?.lua" LUA_CPATH='.libs/lib?.so' lua -e "srcdir=\"${SRCDIR}\"" -llunit - "$@"


### PR DESCRIPTION
The old hack with TESTS_ENVIRONMENT no longer works. I do not know which
automake version it worked with, but it causes problems now. So, this
commit instead uses a LOG_COMPILER for the same job.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

@osch Is this okay with you?

I also briefly tried making the test suite work with Lua 5.3, but... meh, quickly gave up. It might be a good idea to set up Travis CI integration for this, but... also meh.